### PR TITLE
Add a Jenkins plugin to expose embeddable build status icons

### DIFF
--- a/recipes/_master-config-jenkins.rb
+++ b/recipes/_master-config-jenkins.rb
@@ -25,7 +25,7 @@ template "#{node['jenkins']['master']['home']}/users/chef/config.xml" do
   })
 end
 
-%w(notification ssh-credentials groovy cygpath job-dsl build-flow-plugin rebuild greenballs build-timeout copyartifact email-ext slack throttle-concurrents dashboard-view parameterized-trigger ansicolor).each do |plugin|
+%w(notification ssh-credentials groovy cygpath job-dsl build-flow-plugin rebuild greenballs build-timeout copyartifact email-ext slack throttle-concurrents dashboard-view parameterized-trigger ansicolor embeddable-build-status).each do |plugin|
   plugin, version = plugin.split('=') # in case we decide to pin versions later
   jenkins_plugin plugin
 end


### PR DESCRIPTION
I find that I sometimes add a link to a manually triggered build
in the comments of a pull request.

This plugin will allow the link to be rendered as an image showing
the status of the build, saving some clicks.

https://wiki.jenkins-ci.org/display/JENKINS/Embeddable+Build+Status+Plugin
